### PR TITLE
Fixed some cases that requires quotes in pubspec.lock files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.0.1] - Fixing cases that requires quotes in pubspecLock
+* Added two more cases that requires quotes in pubspecLock files
+* Removed deprecated lint rule (invariant_booleans)
+
 ## [3.0.0] - Rewrite for output correctness and beautification
 * Complete rewrite of YAML formatter
 * Correct handling of nested structures

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -72,7 +72,6 @@ linter:
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
-    - invariant_booleans
     - iterable_contains_unrelated_type
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings

--- a/dev/generate_code.sh
+++ b/dev/generate_code.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 find . -name '*.g.dart' | xargs rm -f
-pub run build_runner build --delete-conflicting-outputs
+dart run build_runner build --delete-conflicting-outputs
 find . -name '*.g.dart' | xargs -I % sh -c 'cat dev/ignored_lint_warning_for_generated_code.txt >> %'
 dev/format_dart_code.sh
 

--- a/lib/src/json2yaml.dart
+++ b/lib/src/json2yaml.dart
@@ -178,7 +178,10 @@ bool _requiresQuotes(String s, YamlStyle yamlStyle) =>
     _isBoolean(s) ||
     _containsSpecialCharacters(s) ||
     (yamlStyle == YamlStyle.pubspecLock &&
-        (s.contains('.') || s.contains(' ')));
+        (s.contains('.') ||
+            s.contains(' ') ||
+            s.contains('/') ||
+            s.startsWith(RegExp('[0-9]'))));
 
 bool _isNumeric(String s) => s.isNotEmpty && num.tryParse(s) != null;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: |-
   * Built-in automatic beautifer
   * Supports Dart pubspec.yaml conventions
   * Compatible with conventions imposed by Dart pubspec.lock generator
-version: 3.0.0
+version: 3.0.1
 homepage: https://github.com/alexei-sintotski/json2yaml
 
 environment:


### PR DESCRIPTION
This fixes two issues

Consider this package dependency
```
  window_size:
    dependency: transitive
    description:
      path: "plugins/window_size"
      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
      resolved-ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
      url: "https://github.com/google/flutter-desktop-embedding.git"
    source: git
    version: "0.1.0"
```

These 2 lines were not being constructed correctly
```
      path: "plugins/window_size"
      ref: "03d957e8b5c99fc83cd4a781031b154ab3de8753"
```

The smoke test was not being able to catch this issue because it has no dependency like this one.
However, since dart 2.19, we have a new field called sha256 that makes this issue more obvious

Example:
```
args:
    dependency: transitive
    description:
      name: args
      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
      url: "https://pub.dev"
    source: hosted
    version: "2.3.2"
```
And to justify the rule I added to check if the string begins with a digit, check this other dependency
```
  async:
    dependency: transitive
    description:
      name: async
      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
      url: "https://pub.dev"
    source: hosted
    version: "2.10.0"
```
As you can see, there are no quotes in this case. I verified with a lot of other examples, and it seems to be the case